### PR TITLE
add workaround for sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: required
+
+services:
+  - docker
+
+before_install:
+  - sudo apt-get update
+  - sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" install docker-engine
+  - docker -v
+
+install:
+  - make
+
+script:
+  - ./runtest.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ RUN sed -i \
 	/usr/bin/ssh-keygen -q -t rsa -f /etc/ssh/ssh_host_rsa_key \
 	-C '' -N ''
 
+# To avoid error: sudo: sorry, you must have a tty to run sudo
+RUN sed -i -e "s/Defaults    requiretty.*/ #Defaults    requiretty/g" /etc/sudoers
+
 RUN useradd omero && \
 	echo 'omero:omero' | chpasswd omero &&\
 	echo "omero ALL= (ALL) NOPASSWD: ALL" >> /etc/sudoers.d/omero

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+NS = openmicroscopy
+VERSION ?= local
+
+REPO = omero-ssh-daemon-c7
+NAME = omero-ssh-daemon-c7
+
+build:
+	docker build $(BUILDARGS) -t $(NS)/$(REPO):$(VERSION) .
+
+shell:
+	docker run --rm --name $(NAME) -i -t $(PORTS) $(VOLUMES) $(ENV) $(NS)/$(REPO):$(VERSION) /bin/bash
+
+run:
+	docker run --rm --name $(NAME) $(PORTS) $(VOLUMES) $(ENV) $(NS)/$(REPO):$(VERSION)
+
+start:
+	docker run -d --name $(NAME) $(PORTS) $(VOLUMES) $(ENV) $(NS)/$(REPO):$(VERSION)
+
+stop:
+	docker stop $(NAME)
+
+rm:
+	docker rm $(NAME)
+
+default: build
+
+.PHONY: build push shell run start stop rm release

--- a/runtest.sh
+++ b/runtest.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e -u -x
+
+PRIVILEGED=""
+VOLUMES=""
+# start docker container
+if [[ "darwin" == "${OSTYPE//[0-9.]/}" ]]; then
+    PRIVILEGED="--privileged"
+fi
+
+make start PORTS=$PRIVILEGED
+docker inspect -f {{.State.Running}} omero-ssh-daemon-c7
+
+# CLEANUP
+make stop
+make rm


### PR DESCRIPTION
as we do not have travis yet

```
$ make
docker build  -t openmicroscopy/omero-ssh-daemon-c7:local .
Sending build context to Docker daemon 67.07 kB
Step 1 : FROM centos:centos7
 ---> 778a53015523
Step 2 : MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 ---> Using cache
 ---> 2917cfa3ed2e
Step 3 : RUN yum install -y sudo openssh-server openssh-clients &&  yum clean all
 ---> Using cache
 ---> 48a3062eb898
Step 4 : RUN sed -i     's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g'     /etc/pam.d/sshd &&  /usr/bin/ssh-keygen -q -t rsa -f /etc/ssh/ssh_host_rsa_key  -C '' -N ''
 ---> Using cache
 ---> a65ac78286ba
Step 5 : RUN sed -i -e "s/Defaults    requiretty.*/ #Defaults    requiretty/g" /etc/sudoers
 ---> Using cache
 ---> 77bd020d874b
Step 6 : RUN useradd omero &&   echo 'omero:omero' | chpasswd omero &&  echo "omero ALL= (ALL) NOPASSWD: ALL" >> /etc/sudoers.d/omero
 ---> Using cache
 ---> 3e26a82df1ee
Step 7 : EXPOSE 22
 ---> Using cache
 ---> 32e83eb952c1
Step 8 : CMD /usr/sbin/sshd -eD
 ---> Using cache
 ---> b29e8261e44b
Successfully built b29e8261e44b
```

```
$ ./runtest.sh 
+ PRIVILEGED=
+ VOLUMES=
+ [[ darwin == \d\a\r\w\i\n ]]
+ PRIVILEGED=--privileged
+ make start PORTS=--privileged
docker run -d --name omero-ssh-daemon-c7 --privileged   openmicroscopy/omero-ssh-daemon-c7:local
fe57da25378f5015c35602707bfc1155d56bfa0fd2a1b1c2c9bb751cb3517813
+ docker inspect -f '{{.State.Running}}' omero-ssh-daemon-c7
true
+ make stop
docker stop omero-ssh-daemon-c7
omero-ssh-daemon-c7
+ make rm
docker rm omero-ssh-daemon-c7
omero-ssh-daemon-c7
```
